### PR TITLE
DepthAI KVM host machine package

### DIFF
--- a/host/80-movidius-host.rules
+++ b/host/80-movidius-host.rules
@@ -1,0 +1,9 @@
+SUBSYSTEM=="usb", ACTION=="bind", ENV{ID_VENDOR_ID}=="03e7", MODE="0666", RUN+="/home/maseab/vm_disks/myriad_usb_hotplug.sh main-vm"
+SUBSYSTEM=="usb", ACTION=="remove", ENV{PRODUCT}=="3e7/2485/1", ENV{DEVTYPE}=="usb_device", MODE="0666", RUN+="/home/maseab/vm_disks/myriad_usb_hotplug.sh main-vm"
+SUBSYSTEM=="usb", ACTION=="remove", ENV{PRODUCT}=="3e7/f63b/100", ENV{DEVTYPE}=="usb_device", MODE="0666", RUN+="/home/maseab/vm_disks/myriad_usb_hotplug.sh main-vm"
+
+# In the guest machine use the following rules.
+#SUBSYSTEM=="usb", ATTRS{idProduct}=="2150", ATTRS{idVendor}=="03e7", GROUP="users", MODE="0666"
+#SUBSYSTEM=="usb", ATTRS{idProduct}=="2485", ATTRS{idVendor}=="03e7", GROUP="users", MODE="0666"
+#SUBSYSTEM=="usb", ATTRS{idProduct}=="f63b", ATTRS{idVendor}=="03e7", GROUP="users", MODE="0666"
+#SUBSYSTEM=="usb", ATTRS{idProduct}=="f63c", ATTRS{idVendor}=="03e7", GROUP="users", MODE="0666"

--- a/host/debian/control
+++ b/host/debian/control
@@ -1,0 +1,10 @@
+Package: depthai-ctrl-host
+Version: VERSION
+Maintainer: Manuel Segarra-Abad <manuel.segarra-abad@unikie.com>
+Architecture: amd64
+Depends: udev, libvirt-clients
+Conflicts: ros-foxy-depthai-ctrl
+Description: Provides udev rules for host machine
+ Provides udev rules for host machine. This package configures the passthrough
+ rules for DepthAI control ROS2 node running in guest virtual machine.
+

--- a/host/debian/postinst
+++ b/host/debian/postinst
@@ -1,0 +1,7 @@
+#!/bin/bash
+
+udevadm control --reload-rules
+udevadm trigger
+
+exit 0
+

--- a/host/debian/postrm
+++ b/host/debian/postrm
@@ -1,0 +1,7 @@
+#!/bin/bash
+
+udevadm control --reload-rules
+udevadm trigger
+
+exit 0
+

--- a/host/movidius_usb_hotplug.sh
+++ b/host/movidius_usb_hotplug.sh
@@ -1,0 +1,64 @@
+#!/bin/bash
+
+
+# Abort script execution on errors
+set -e
+
+PROG="$(basename "$0")"
+
+# Log everything to syslog.
+exec 1> >(logger -s -t ${PROG}) 2>&1
+
+DOMAIN="$1"
+if [ -z "${DOMAIN}" ]; then
+  echo "Missing libvirt domain parameter for ${PROG}." >&2
+  exit 1
+fi
+
+IFS=: read VAR1 VAR2 <<< $(virsh dominfo main-vm | grep State)
+DOMAIN_STATE="$(echo -e "${VAR2}" | tr -d '[:space:]')"
+if [ "${DOMAIN_STATE}" != 'running' ]; then
+  echo "Domain ${DOMAIN} state (${DOMAIN_STATE}) is not running. Nothing to do to DepthAI camera." >&2
+  exit 0
+fi
+
+if [ -z "${ACTION}" ]; then
+  echo "Missing udev ACTION environment variable." >&2
+  exit 1
+fi
+
+if [ "${ACTION}" == 'bind' ]; then
+  COMMAND='attach-device'
+elif [ "${ACTION}" == 'remove' ]; then
+  COMMAND='detach-device'
+  if [ "${PRODUCT}" == '3e7/2485/1' ]; then
+    ID_VENDOR_ID=03e7
+    ID_MODEL_ID=2485
+  fi
+  if [ "${PRODUCT}" == '3e7/f63b/100' ]; then
+    ID_VENDOR_ID=03e7
+    ID_MODEL_ID=f63b
+  fi
+else
+  echo "Invalid udev ACTION: ${ACTION}" >&2
+  exit 1
+fi
+
+DEVNUM=$((10#$DEVNUM))
+
+#
+# Now we have all the information we need to update the VM.
+# Run the appropriate virsh-command, and ask it to read the
+# update XML from stdin.
+#
+echo "Running virsh ${COMMAND} ${DOMAIN} for ${ID_VENDOR}." >&2
+virsh "${COMMAND}" "${DOMAIN}" /dev/stdin <<END
+<hostdev mode='subsystem' type='usb'>
+  <source>
+    <vendor id='0x${ID_VENDOR_ID}'/>
+    <product id='0x${ID_MODEL_ID}'/>
+  </source>
+</hostdev>
+END
+
+exit 0

--- a/host/package.sh
+++ b/host/package.sh
@@ -1,0 +1,32 @@
+#!/bin/bash
+
+get_version() {
+    version=1.0.0~$(git describe --always --tags --match "[0-9]*.[0-9]*.[0-9]*")
+    echo ${version}
+}
+
+make_deb() {
+	echo "Creating deb package..."
+	build_dir=$(mktemp -d)
+	mkdir ${build_dir}/DEBIAN
+	mkdir -p ${build_dir}/usr/local/bin
+	mkdir -p ${build_dir}/etc/udev/rules.d
+	cp debian/control ${build_dir}/DEBIAN/
+	cp debian/postinst ${build_dir}/DEBIAN/
+	cp debian/postrm ${build_dir}/DEBIAN/
+	cp movidius_usb_hotplug.sh ${build_dir}/usr/local/bin/
+	cp 80-movidius-host.rules ${build_dir}/etc/udev/rules.d/
+	chmod +x ${build_dir}/usr/local/bin/movidius_usb_hotplug.sh
+	chmod 644 ${build_dir}/etc/udev/rules.d/80-movidius-host.rules
+
+	get_version
+	sed -i "s/VERSION/${version}/" ${build_dir}/DEBIAN/control
+	cat ${build_dir}/DEBIAN/control
+	echo depthai-ctrl-host_${version}_amd64.deb
+	fakeroot dpkg-deb --build ${build_dir} ../depthai-ctrl-host_${version}_amd64.deb
+	rm -rf ${build_dir}
+	echo "Done"
+}
+
+version=$(get_version)
+make_deb


### PR DESCRIPTION
The KVM host machine needs udev rules to be able to attach and detach
the DepthAI camera when it changes the USB model ID.