### PR TITLE
Version 0.5 of depthai_ctrl

### DIFF
--- a/package.xml
+++ b/package.xml
@@ -2,7 +2,7 @@
 <?xml-model href="http://download.ros.org/schema/package_format3.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
 <package format="3">
   <name>depthai_ctrl</name>
-  <version>0.4.0</version>
+  <version>0.5.0</version>
   <description>DepthAI camera control ROS2 node</description>
   <maintainer email="manuel.segarra-abad@unikie.com">Manuel Segarra-Abad</maintainer>
   <license>TODO: License declaration</license>


### PR DESCRIPTION
This version contains videonode functionality: RTSP client connection.
The UDP connection has been kept as configurable option.