### PR TITLE
Add gst ugly dep

### DIFF
--- a/debian/control.em
+++ b/debian/control.em
@@ -11,7 +11,7 @@ Package: @(Package)
 Architecture: any
 Depends: ${shlibs:Depends}, ${misc:Depends}, @(', '.join(Depends)),
  gstreamer1.0-plugins-bad, libgstreamer1.0-0, gstreamer1.0-libav,
- gir1.2-gst-rtsp-server-1.0, gstreamer1.0-rtsp
+ gir1.2-gst-rtsp-server-1.0, gstreamer1.0-rtsp, gstreamer1.0-plugins-ugly
 @[if Conflicts]Conflicts: @(', '.join(Conflicts))@\n@[end if]@
 @[if Replaces]Replaces: @(', '.join(Replaces))@\n@[end if]@
 Description: @(Description)

--- a/depthai_ctrl.cpp
+++ b/depthai_ctrl.cpp
@@ -26,9 +26,9 @@ using std::placeholders::_1;
 
 #define DEPTHAI_CTRL_VER_MAJOR 0
 #define DEPTHAI_CTRL_VER_MINOR 5
-// The CI build will add a build number after the minor version.
+#define DEPTHAI_CTRL_VER_PATCH 0
 
-#define DEPTHAI_CTRL_VERSION (DEPTHAI_CTRL_VER_MAJOR * 100 + DEPTHAI_CTRL_VER_MINOR)
+#define DEPTHAI_CTRL_VERSION (DEPTHAI_CTRL_VER_MAJOR * 10000 + DEPTHAI_CTRL_VER_MINOR * 100 + DEPTHAI_CTRL_VER_PATCH)
 
 
 class DepthAICam


### PR DESCRIPTION
Missing dependency of gstreamer ugly plugins. This is needed when camera is not detected and a video stream is generated to indicated to the user that the depthAI camera was not detected but stream is available.