### PR TITLE
Use system default QoS to support xml profiles define

### DIFF
--- a/depthai_ctrl.cpp
+++ b/depthai_ctrl.cpp
@@ -670,7 +670,7 @@ class DepthAICamCtrl : public rclcpp::Node
         : Node("depthai_cam_ctrl"), mDepthAIGst(nullptr)
         {
             subscription_ = this->create_subscription<std_msgs::msg::String>(
-                "videostreamcmd", 10, std::bind(&DepthAICamCtrl::depthai_rgb_cam_cmd_cb,
+                "videostreamcmd", rclcpp::SystemDefaultsQoS(), std::bind(&DepthAICamCtrl::depthai_rgb_cam_cmd_cb,
                 this, _1));
             if (depthAIGst != nullptr) {
                 mDepthAIGst = depthAIGst;


### PR DESCRIPTION
ROS2 publisher & subscriber QoS profiles are defined in DEFAULT_FASTRTPS_PROFILES.xml. To make ROS2 node support for it the systemDefaultsQoS needs to be loaded when creating publisher/subscriber

System default QoS profile needs to be used to minimize meta traffic in narrowband mesh network.