### PR TITLE
Cmd qos change

### DIFF
--- a/host/package.sh
+++ b/host/package.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 get_version() {
-    version=2.0.3~$(git describe --always --tags --match "[0-9]*.[0-9]*.[0-9]*")
+    version=2.0.4~$(git describe --always --tags --match "[0-9]*.[0-9]*.[0-9]*")
     echo ${version}
 }
 

--- a/package.xml
+++ b/package.xml
@@ -2,7 +2,7 @@
 <?xml-model href="http://download.ros.org/schema/package_format3.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
 <package format="3">
   <name>depthai_ctrl</name>
-  <version>2.0.3</version>
+  <version>2.0.4</version>
 
   <description>DepthAI camera control ROS2 node</description>
   <maintainer email="manuel.segarra-abad@unikie.com">Manuel Segarra-Abad</maintainer>

--- a/src/depthai_camera.cpp
+++ b/src/depthai_camera.cpp
@@ -152,6 +152,11 @@ void DepthAICamera::VideoStreamCommand(std_msgs::msg::String::SharedPtr msg)
         _useRawColorCam = useRawColorCam;
         _useAutoFocus = useAutoFocus;
 
+        _auto_focus_timer->reset();
+        _auto_focus_timer =
+          this->create_wall_timer(
+          std::chrono::duration<double>(10.0),
+          std::bind(&DepthAICamera::AutoFocusTimer, this));
         TryRestarting();
       } else {
         RCLCPP_ERROR(this->get_logger(), error_message.c_str());
@@ -197,6 +202,7 @@ void DepthAICamera::VideoStreamCommand(std_msgs::msg::String::SharedPtr msg)
         return;
       } 
       RCLCPP_INFO(this->get_logger(), "Stopping video stream");
+      _firstFrameReceived = false;
       Stop();
     }
   }

--- a/src/depthai_camera.cpp
+++ b/src/depthai_camera.cpp
@@ -34,7 +34,7 @@ void DepthAICamera::Initialize()
     video_stream_topic,
     rclcpp::SystemDefaultsQoS());
   _stream_command_subscriber = create_subscription<std_msgs::msg::String>(
-    stream_control_topic, rclcpp::SystemDefaultsQoS(),
+    stream_control_topic, rclcpp::QoS(10).reliable(),
     std::bind(&DepthAICamera::VideoStreamCommand, this, _1));
 
   _auto_focus_timer =


### PR DESCRIPTION
Change QoS for videostreamcmd to reliable with 10 queue size. This prevents messages being dropped during spoofing attack. Also added changing lens position timer to work after its restarted.