### PR TITLE
[DO NOT MERGE]-Bump tiiuae/fog-ros-baseimage from v1.0.0 to dp-4266_humble_upgrade

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM ghcr.io/tiiuae/fog-ros-baseimage-builder:v1.0.0 AS builder
+FROM ghcr.io/tiiuae/fog-ros-baseimage-builder:dp-4266_humble_upgrade AS builder
 
 # TODO: not sure how many of these deps are actually needed for building. at least this:
 # libusb-1.0-0-dev
@@ -26,7 +26,7 @@ RUN /packaging/build.sh
 #  ▲               runtime ──┐
 #  └── build                 ▼
 
-FROM ghcr.io/tiiuae/fog-ros-baseimage:v1.0.0
+FROM ghcr.io/tiiuae/fog-ros-baseimage:dp-4266_humble_upgrade
 
 ENTRYPOINT [ "/entrypoint.sh" ]
 


### PR DESCRIPTION
Update fog-ros-baseimage from v1.0.0 to dp-4266_humble_upgrade
This PR is auto generated by a remote workflow.
Message from author of this PR;
**This is a test PR to check if the container is ready for ROS2 Humble upgrade. Do not merge until confirmed.**