### PR TITLE
Bump baseimage from v3.0.1 to v3.0.2

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -6,7 +6,7 @@
 version: 2
 updates:
   - package-ecosystem: "docker"
-    directory: "/"
+    directory: "/Dockerfile"
     schedule:
       interval: "daily"
     groups:

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM --platform=${BUILDPLATFORM:-linux/amd64} ghcr.io/tiiuae/fog-ros-sdk:v3.0.1-${TARGETARCH:-amd64} AS builder
+FROM --platform=${BUILDPLATFORM:-linux/amd64} ghcr.io/tiiuae/fog-ros-sdk:v3.0.2-${TARGETARCH:-amd64} AS builder
 
 ARG TARGETARCH
 
@@ -31,7 +31,7 @@ RUN /packaging/build_colcon_sdk.sh ${TARGETARCH:-amd64}
 #  ▲               runtime ──┐
 #  └── build                 ▼
 
-FROM ghcr.io/tiiuae/fog-ros-baseimage:v3.0.1
+FROM ghcr.io/tiiuae/fog-ros-baseimage:v3.0.2
 
 RUN apt update \
     && apt install -y --no-install-recommends \
@@ -51,6 +51,7 @@ RUN apt update \
         libopencv-ts \
         opencv-staticdev \
         libdepthai-core20 \
+    && apt clean \
     && rm -rf /var/lib/apt/lists/*
 
 RUN mkdir /depthai_configs


### PR DESCRIPTION
Update fog-ros-baseimage from v3.0.1 to v3.0.2