### PR TITLE
Dependabot updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -11,11 +11,15 @@ updates:
       interval: "daily"
     groups:
       baseimage-dependencies:
-          patterns:
-            - "tiiuae/fog-ros-sdk"
-            - "tiiuae/fog-ros-baseimage-builder"
-            - "tiiuae/fog-ros-baseimage"
+        patterns:
+          - "tiiuae/fog-ros-sdk"
+          - "tiiuae/fog-ros-baseimage-builder"
+          - "tiiuae/fog-ros-baseimage"
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:
       interval: "weekly"
+    groups:
+      github-actions:
+        patterns:
+          - "*"

--- a/.github/workflows/tii-depthai-ctrl-coverity.yaml
+++ b/.github/workflows/tii-depthai-ctrl-coverity.yaml
@@ -15,17 +15,17 @@ jobs:
         with:
           submodules: recursive
       - name: Login to GitHub Container Registry
-        uses: docker/login-action@v2
+        uses: docker/login-action@v3
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v2
+        uses: docker/setup-buildx-action@v3
         with:
           driver: docker
       - name: Build and push
-        uses: docker/build-push-action@v4
+        uses: docker/build-push-action@v5
         with:
           context: .
           file: Dockerfile.coverity

--- a/.github/workflows/tii-depthai-ctrl.yaml
+++ b/.github/workflows/tii-depthai-ctrl.yaml
@@ -63,7 +63,7 @@ jobs:
             matrix_json+="{\"platform\":\"$platform\"},"
           done
           matrix_json="${matrix_json%,}]}"
-          echo "::set-output name=matrix::$matrix_json"
+          echo "matrix=${matrix_json}" >> $GITHUB_OUTPUT
           echo $matrix_json
 
   build:
@@ -137,7 +137,7 @@ jobs:
 
       - name: Docker meta
         id: meta
-        uses: docker/metadata-action@v4
+        uses: docker/metadata-action@v5
         with:
           images: ${{ env.REGISTRY_IMAGE }}
 


### PR DESCRIPTION
Bump docker/login-action from 2 to 3
Bump docker/metadata-action from 4 to 5
Bump docker/setup-buildx-action from 2 to 3
Bump docker/build-push-action from 4 to 5

change set-output to $GITHUB_OUTPUT to get rid of warning