### PR TITLE
[PX4-MSGS-UPGRADE]Bump tiiuae/fog-ros-baseimage from v3.0.2 to v3.1.0

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM --platform=${BUILDPLATFORM:-linux/amd64} ghcr.io/tiiuae/fog-ros-sdk:sha-9a1be77-${TARGETARCH:-amd64} AS builder
+FROM --platform=${BUILDPLATFORM:-linux/amd64} ghcr.io/tiiuae/fog-ros-sdk:v3.1.0-${TARGETARCH:-amd64} AS builder
 
 ARG TARGETARCH
 
@@ -31,7 +31,7 @@ RUN /packaging/build_colcon_sdk.sh ${TARGETARCH:-amd64}
 #  ▲               runtime ──┐
 #  └── build                 ▼
 
-FROM ghcr.io/tiiuae/fog-ros-baseimage:sha-9a1be77
+FROM ghcr.io/tiiuae/fog-ros-baseimage:v3.1.0
 
 RUN apt update \
     && apt install -y --no-install-recommends \

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM --platform=${BUILDPLATFORM:-linux/amd64} ghcr.io/tiiuae/fog-ros-sdk:v3.0.2-${TARGETARCH:-amd64} AS builder
+FROM --platform=${BUILDPLATFORM:-linux/amd64} ghcr.io/tiiuae/fog-ros-sdk:sha-9a1be77-${TARGETARCH:-amd64} AS builder
 
 ARG TARGETARCH
 
@@ -31,7 +31,7 @@ RUN /packaging/build_colcon_sdk.sh ${TARGETARCH:-amd64}
 #  ▲               runtime ──┐
 #  └── build                 ▼
 
-FROM ghcr.io/tiiuae/fog-ros-baseimage:v3.0.2
+FROM ghcr.io/tiiuae/fog-ros-baseimage:sha-9a1be77
 
 RUN apt update \
     && apt install -y --no-install-recommends \


### PR DESCRIPTION
Update fog-ros-baseimage from sha-9a1be77 to v3.1.0
This PR is auto generated by a remote workflow.
Message from author of this PR;
**This version update includes the baseimage with px4-msgs 6.0.0. Components that are not using the PX4-msgs shouldnt get affected by this change.**
