### PR TITLE
Update ros-baseimage version to sha-c66a922

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM --platform=${BUILDPLATFORM:-linux/amd64} ghcr.io/tiiuae/fog-ros-sdk:v3.2.0-${TARGETARCH:-amd64} AS builder
+FROM --platform=${BUILDPLATFORM:-linux/amd64} ghcr.io/tiiuae/fog-ros-sdk:sha-c66a922-${TARGETARCH:-amd64} AS builder
 
 ARG TARGETARCH
 
@@ -31,7 +31,7 @@ RUN /packaging/build_colcon_sdk.sh ${TARGETARCH:-amd64}
 #  ▲               runtime ──┐
 #  └── build                 ▼
 
-FROM ghcr.io/tiiuae/fog-ros-baseimage:v3.2.0
+FROM ghcr.io/tiiuae/fog-ros-baseimage:sha-c66a922
 
 RUN apt update \
     && apt install -y --no-install-recommends \


### PR DESCRIPTION
This pull request updates the ros-baseimage version to sha-c66a922.